### PR TITLE
 Use ENV instead of JSON for config

### DIFF
--- a/bugsnag-api/README.md
+++ b/bugsnag-api/README.md
@@ -1,7 +1,7 @@
 # Bugsnag API filtering script
 
 Based on: https://github.com/Gusto/adams-sandbox/tree/master/bugsnag-api.   
-Make sure to update secrets.json with your key, in the format of `secrets_example.json`.
+Make sure to update secrets.sh with your key, in the format of `secrets_example.sh`.
 
 ## Example: Get event counts over past 60d for transient errors
 

--- a/bugsnag-api/get_all_errors.rb
+++ b/bugsnag-api/get_all_errors.rb
@@ -4,8 +4,7 @@ require 'bugsnag/api'
 require 'pry'
 require 'json'
 
-secrets_json = File.read("secrets.json")
-token = JSON.parse(secrets_json)['bugsnag_auth_token']
+token = ENV['bugsnag_auth_token']
 
 cache_json = File.exist?("cache.json") && File.read("cache.json")
 $cache = cache_json ? JSON.parse(cache_json) : {}

--- a/bugsnag-api/secrets_example.json
+++ b/bugsnag-api/secrets_example.json
@@ -1,3 +1,0 @@
-{
-  "bugsnag_auth_token": "b7384a86-7721-447c-bf75-2efc62045f7d"
-}

--- a/bugsnag-api/secrets_example.sh
+++ b/bugsnag-api/secrets_example.sh
@@ -1,0 +1,1 @@
+export bugsnag_auth_token=b7384a86-7721-447c-bf75-2efc62045f7d


### PR DESCRIPTION
Stores the API key in a SH file instead of a JSON file to adhere to 12 factor guidelines:

Env vars are easy to change between deploys without changing any code; unlike config files, there is little chance of them being checked into the code repo accidentally; and unlike custom config files, or other config mechanisms such as Java System Properties, they are a language- and OS-agnostic standard. (https://12factor.net/config)

I would also add that because the key and value both have to be plain text, it discourages
adding more complicated things as config settings when they really ought
not to need to be. 

On the negative side, envs can leak to logging and and error handling services in ways JSON might not, and they only support strings.

For more complicated uses can look into Figaro and dotenv: 

https://github.com/laserlemon/figaro
https://github.com/bkeepers/dotenv